### PR TITLE
Add support for `save_tree_error` train argument to preserve `record_evals`

### DIFF
--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -113,6 +113,9 @@ add_boost_tree_lightgbm <- function() {
 #'   construction, set \code{free_raw_data = FALSE}. Useful for debugging.
 #' @param verbose Integer. < 0: Fatal, = 0: Error (Warning), = 1: Info,
 #'   > 1: Debug.
+#' @param save_tree_error Boolean. Whether or not to use the training set
+#'   to compute errors for each tree that will be stored on the record_evals
+#'   attribute.
 #' @param ... Engine arguments, hyperparameters, etc. that are passed on to
 #'   \code{\link[lightgbm]{lgb.train}}.
 #'

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -270,8 +270,6 @@ train_lightgbm <- function(x,
     main_args$early_stopping_rounds <- early_stop
   }
 
-  print("Calling lgb.train with the following args:")
-  print(main_args)
   call <- parsnip::make_call(fun = "lgb.train", ns = "lightgbm", main_args)
   rlang::eval_tidy(call, env = rlang::current_env())
 }

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -129,6 +129,7 @@ train_lightgbm <- function(x,
                            categorical_feature = NULL,
                            weight = NULL,
                            validation = 0,
+                           valids = list(),
                            sample_type = "random",
                            early_stop = NULL,
                            max_bin = NULL,
@@ -217,6 +218,14 @@ train_lightgbm <- function(x,
       trn_index <- seq(1, max(m, 2))
       val_index <- setdiff(1:n, trn_index)
     }
+    if (length(valids) > 0) {
+      rlang::warn(
+        paste0(
+          "`validation` and `valids` are both set; overriding `valids` with ",
+          "a sample of the training data."
+        )
+      )
+    }
     valids <- list(validation = lightgbm::lgb.Dataset(
       data = as.matrix(x[val_index, , drop = FALSE]),
       label = y[val_index],
@@ -247,8 +256,10 @@ train_lightgbm <- function(x,
     verbose = verbose
   )
 
-  if (!is.null(early_stop) && validation > 0) {
+  if (length(valids) > 0) {
     main_args$valids <- quote(valids)
+  }
+  if (!is.null(early_stop) && validation > 0) {
     main_args$early_stopping_rounds <- early_stop
   }
 

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -239,6 +239,7 @@ train_lightgbm <- function(x,
   }
 
   if (save_tree_error) {
+    print("Enabling save_tree_error")
     full_valid_set <- lightgbm::lgb.Dataset(
       data = as.matrix(x),
       label = y,
@@ -248,8 +249,10 @@ train_lightgbm <- function(x,
       free_raw_data = free_raw_data
     )
     if (exists("valids")) {
+      print("valids exists; adding tree_error to it")
       valids$tree_errors <- full_valid_set
     } else {
+      print("valids does not exist; creating it with tree_errors")
       valids <- list(tree_errors = full_valid_set)
     }
   }
@@ -279,6 +282,8 @@ train_lightgbm <- function(x,
     main_args$early_stopping_rounds <- early_stop
   }
 
+  print("Calling lgb.train with the following args:")
+  print(main_args)
   call <- parsnip::make_call(fun = "lgb.train", ns = "lightgbm", main_args)
   rlang::eval_tidy(call, env = rlang::current_env())
 }

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -146,10 +146,6 @@ train_lightgbm <- function(x,
   force(y)
   others <- list(...)
 
-  if (save_tree_error && validation > 0) {
-    stop("`save_tree_error` cannot be `TRUE` when `validation > 0`")
-  }
-
   # Set training objective (always regression)
   if (!any(names(others) %in% c("objective"))) {
     others$num_class <- 1
@@ -249,6 +245,9 @@ train_lightgbm <- function(x,
   )
 
   if (save_tree_error) {
+    if (validation > 0) {
+      stop("`save_tree_error` cannot be `TRUE` when `validation > 0`")
+    }
     if (verbose > 0) {
       message("Enabling save_tree_error")
     }

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -115,7 +115,9 @@ add_boost_tree_lightgbm <- function() {
 #'   > 1: Debug.
 #' @param save_tree_error Boolean. Whether or not to use the training set
 #'   to compute errors for each tree that will be stored on the record_evals
-#'   attribute.
+#'   attribute. Note that this parameter is mutually exclusive with
+#'   \code{validation} and \code{early_stop} because otherwise it can override
+#'   the set used for cross validation.
 #' @param ... Engine arguments, hyperparameters, etc. that are passed on to
 #'   \code{\link[lightgbm]{lgb.train}}.
 #'
@@ -143,6 +145,10 @@ train_lightgbm <- function(x,
   force(x)
   force(y)
   others <- list(...)
+
+  if (save_tree_error && validation > 0) {
+    stop("`save_tree_error` cannot be `TRUE` when `validation > 0`")
+  }
 
   # Set training objective (always regression)
   if (!any(names(others) %in% c("objective"))) {
@@ -243,14 +249,10 @@ train_lightgbm <- function(x,
   )
 
   if (save_tree_error) {
-    print("Enabling save_tree_error")
-    if (exists("valids")) {
-      print("valids exists; adding tree_errors to it")
-      valids$tree_errors <- d
-    } else {
-      print("valids does not exist; creating it with tree_errors")
-      valids <- list(tree_errors = d)
+    if (verbose > 0) {
+      message("Enabling save_tree_error")
     }
+    valids <- list(tree_errors = d)
   }
 
 

--- a/man/train_lightgbm.Rd
+++ b/man/train_lightgbm.Rd
@@ -81,7 +81,9 @@ construction, set \code{free_raw_data = FALSE}. Useful for debugging.}
 
 \item{save_tree_error}{Boolean. Whether or not to use the training set
 to compute errors for each tree that will be stored on the record_evals
-attribute.}
+attribute. Note that this parameter is mutually exclusive with \code{validation}
+and \code{early_stop} because otherwise it can override the set used for cross
+validation.}
 
 \item{...}{Engine arguments, hyperparameters, etc. that are passed on to
 \code{\link[lightgbm]{lgb.train}}.}

--- a/man/train_lightgbm.Rd
+++ b/man/train_lightgbm.Rd
@@ -21,6 +21,7 @@ train_lightgbm(
   feature_pre_filter = FALSE,
   free_raw_data = TRUE,
   verbose = 0,
+  save_tree_error = FALSE,
   ...
 )
 }
@@ -77,6 +78,10 @@ construction, set \code{free_raw_data = FALSE}. Useful for debugging.}
 
 \item{verbose}{Integer. < 0: Fatal, = 0: Error (Warning), = 1: Info,
 > 1: Debug.}
+
+\item{save_tree_error}{Boolean. Whether or not to use the training set
+to compute errors for each tree that will be stored on the record_evals
+attribute.}
 
 \item{...}{Engine arguments, hyperparameters, etc. that are passed on to
 \code{\link[lightgbm]{lgb.train}}.}

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -112,6 +112,9 @@ test_that("model can be saved and loaded", {
 
   reloaded <- lgbm_load(file)
 
+  # Make sure record_evals got preserved during saving/loading
+  expect_equal(length(reloaded$fit$record_evals$tree_errors$l2$eval), 50)
+
   out <- predict(
     reloaded,
     recipes::bake(

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -52,7 +52,8 @@ library(modeldata)
 # Prep lightgbm model
 model <- parsnip::boost_tree(mtry = 1, trees = 50, tree_depth = 15, min_n = 1)
 model <- parsnip::set_engine(
-  model, "lightgbm", verbose = -1L, save_tree_error = TRUE
+  model, "lightgbm",
+  verbose = -1L, save_tree_error = TRUE
 )
 model <- parsnip::set_mode(model, "regression")
 

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -51,7 +51,9 @@ library(modeldata)
 
 # Prep lightgbm model
 model <- parsnip::boost_tree(mtry = 1, trees = 50, tree_depth = 15, min_n = 1)
-model <- parsnip::set_engine(model, "lightgbm", verbose = -1L)
+model <- parsnip::set_engine(
+  model, "lightgbm", verbose = -1L, save_tree_error = TRUE
+)
 model <- parsnip::set_mode(model, "regression")
 
 # Prep input data with recipe

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -82,6 +82,38 @@ test_that("lightgbm alternate objective", {
   expect_equal(info$objective, "huber")
 })
 
+test_that("lightgbm with save_tree_error", {
+  model <- parsnip::boost_tree(trees = 50) %>%
+    parsnip::set_engine(
+      engine = "lightgbm",
+      objective = "regression", verbose = -1,
+      max_depth = 15, feature_fraction = 1, min_data_in_leaf = 1,
+      save_tree_error = TRUE
+    ) %>%
+    parsnip::set_mode("regression")
+
+  expect_regression_works(model)
+
+  # TODO: Correct comparison
+  expect_equal(model$fit$record_evals$tree_errors, data.frame())
+})
+
+test_that("lightgbm with save_tree_error and validation", {
+  model <- parsnip::boost_tree(trees = 50, stop_iter = 2) %>%
+    parsnip::set_engine(
+      engine = "lightgbm",
+      objective = "regression", verbose = -1,
+      max_depth = 15, feature_fraction = 1, min_data_in_leaf = 1,
+      save_tree_error = TRUE, validation = 0.25
+    ) %>%
+    parsnip::set_mode("regression")
+
+  expect_regression_works(model)
+
+  # TODO: Correct comparison
+  expect_equal(model$fit$record_evals$tree_errors, data.frame())
+})
+
 test_that("lighgbm throws error", {
   expect_error(
     reg_fit <-

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -82,7 +82,7 @@ test_that("lightgbm alternate objective", {
   expect_equal(info$objective, "huber")
 })
 
-test_that("lightgbm with save_tree_error", {
+test_that("lightgbm with save_tree_error saves record_evals", {
   model_fit <- parsnip::boost_tree(trees = 50) %>%
     parsnip::set_engine(
       engine = "lightgbm",
@@ -99,19 +99,17 @@ test_that("lightgbm with save_tree_error", {
   )
 })
 
-test_that("lightgbm with save_tree_error and validation", {
-  model_fit <- parsnip::boost_tree(trees = 50, stop_iter = 2) %>%
-    parsnip::set_engine(
-      engine = "lightgbm",
-      objective = "regression", metric = "rmse", verbose = -1,
-      max_depth = 15, feature_fraction = 1, min_data_in_leaf = 1,
-      save_tree_error = TRUE, validation = 0.25
-    ) %>%
-    parsnip::set_mode("regression") %>%
-    parsnip::fit(mpg ~ ., data = mtcars)
-
-  expect_gt(length(model_fit$fit$record_evals$tree_errors$rmse$eval), 0)
-  expect_gt(length(model_fit$fit$record_evals$validation$rmse$eval), 0)
+test_that("lightgbm with save_tree_error and validation throws error", {
+  expect_error(
+    reg_fit <-
+      parsnip::boost_tree(trees = 50, stop_iter = 2, mode = "regression") %>%
+      parsnip::set_engine(
+        "lightgbm",
+        save_tree_error = TRUE, validation = 0.25
+      ) %>%
+      parsnip::fit(mpg ~ ., data = mtcars),
+    regex = "`save_tree_error` cannot be `TRUE`"
+  )
 })
 
 test_that("lighgbm throws error", {

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -83,35 +83,35 @@ test_that("lightgbm alternate objective", {
 })
 
 test_that("lightgbm with save_tree_error", {
-  model <- parsnip::boost_tree(trees = 50) %>%
+  model_fit <- parsnip::boost_tree(trees = 50) %>%
     parsnip::set_engine(
       engine = "lightgbm",
-      objective = "regression", verbose = -1,
+      objective = "regression", metric = "rmse", verbose = -1,
       max_depth = 15, feature_fraction = 1, min_data_in_leaf = 1,
       save_tree_error = TRUE
     ) %>%
-    parsnip::set_mode("regression")
+    parsnip::set_mode("regression") %>%
+    parsnip::fit(mpg ~ ., data = mtcars)
 
-  expect_regression_works(model)
-
-  # TODO: Correct comparison
-  expect_equal(model$fit$record_evals$tree_errors, data.frame())
+  expect_equal(
+    length(model_fit$fit$record_evals$tree_errors$rmse$eval),
+    50
+  )
 })
 
 test_that("lightgbm with save_tree_error and validation", {
-  model <- parsnip::boost_tree(trees = 50, stop_iter = 2) %>%
+  model_fit <- parsnip::boost_tree(trees = 50, stop_iter = 2) %>%
     parsnip::set_engine(
       engine = "lightgbm",
-      objective = "regression", verbose = -1,
+      objective = "regression", metric = "rmse", verbose = -1,
       max_depth = 15, feature_fraction = 1, min_data_in_leaf = 1,
       save_tree_error = TRUE, validation = 0.25
     ) %>%
-    parsnip::set_mode("regression")
+    parsnip::set_mode("regression") %>%
+    parsnip::fit(mpg ~ ., data = mtcars)
 
-  expect_regression_works(model)
-
-  # TODO: Correct comparison
-  expect_equal(model$fit$record_evals$tree_errors, data.frame())
+  expect_gt(length(model_fit$fit$record_evals$tree_errors$rmse$eval), 0)
+  expect_gt(length(model_fit$fit$record_evals$validation$rmse$eval), 0)
 })
 
 test_that("lighgbm throws error", {


### PR DESCRIPTION
This PR updates `train_lightgbm` to add support for a boolean `save_tree_error` argument, which allows the caller to specify that the model should use its training data as a validation set in order to save a `record_evals` attribute that records the error for each tree in the model. The PR also tweaks `lgbm_save` and `lgbm_load` in order to support this attribute being (de)serialized when saving or loading the model.

Connects https://github.com/ccao-data/model-res-avm/pull/106.