### PR TITLE
Update `lgbm_load()` to only load `record_evals` if they exist

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Suggests:
     data.table,
     DiagrammeR,
     DiagrammeRsvg,
+    glue,
     hardhat,
     jsonlite,
     kableExtra,

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -92,7 +92,12 @@ lgbm_load <- function(zipfile) {
 
   model <- readRDS(file.path(ex_dir, "meta.model"))
   model$fit <- lightgbm::lgb.load(file.path(ex_dir, "lgbm.model"))
-  model$fit$record_evals <- readRDS(file.path(ex_dir, "record_evals.model"))
+
+  # For backwards-compatibility, only load record_evals if they exist
+  record_evals_path <- file.path(ex_dir, "record_evals.model")
+  if (file.exists(record_evals_path)) {
+    model$fit$record_evals <- readRDS(record_evals_path)
+  }
 
   return(model)
 }

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -136,7 +136,8 @@ test_that("model can be saved and loaded", {
       # We have to remove record_evals.model from the tempdir as well, or else
       # it will still exist when lgbm_load uses the tempdir to extract
       # the new zipfile
-      glue::glue("{tempdir()}/record_evals.model"))
+      glue::glue("{tempdir()}/record_evals.model")
+    )
   )
   new_file <- tempfile(fileext = ".zip")
   zip::zipr(new_file, files = list.files(ex_dir, full.names = TRUE))


### PR DESCRIPTION
In https://github.com/ccao-data/lightsnip/pull/10, we accidentally broke backwards-compatibility in `lgbm_load()` by assuming that the `record_evals.model` object always exists in a model zipfile saved by `lgbm_save()`. Since previous versions of lightsnip did not save this object, `lgbm_load()` will raise an error like the following when attempting to load older models:

```
Error in gzfile(file, "rb") : cannot open the connection
In addition: Warning message:
In gzfile(file, "rb") :
  cannot open compressed file '/tmp/Rtmp0DJ4AJ/record_evals.model', probable reason 'No such file or directory'
```

This change is tested in https://github.com/ccao-data/api-res-avm/pull/2.

Note that codecov is currently failing due to [rate limiting](https://github.com/ccao-data/lightsnip/actions/runs/8913939232/job/24481785581?pr=13#step:5:37), but I haven't added any tests since it ran its [last report](https://github.com/ccao-data/lightsnip/pull/13#issuecomment-2088965105) so I expect it should pass after merging.