### PR TITLE
Upgrade to testthat 3rd edition

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,9 +43,10 @@ Suggests:
     rsample,
     scales,
     snakecase,
-    testthat (>= 2.1.0),
+    testthat (>= 3.0.0),
     tidyr,
     tune,
     workflows,
     yardstick
 RoxygenNote: 7.2.3
+Config/testthat/edition: 3

--- a/tests/testthat/helper-lightgbm.R
+++ b/tests/testthat/helper-lightgbm.R
@@ -102,7 +102,7 @@ expect_can_tune_boost_tree <- function(model) {
   expect_true(all(!is.nan(tune::collect_metrics(adj)$mean)))
 
   final <- model %>%
-    tune::finalize_model(tune::select_best(adj)) %>%
+    tune::finalize_model(tune::select_best(adj, metric = "rmse")) %>%
     parsnip::set_mode("regression") %>%
     parsnip::fit(mpg ~ ., mtcars)
 

--- a/tests/testthat/test-early_stopping.R
+++ b/tests/testthat/test-early_stopping.R
@@ -1,5 +1,3 @@
-context("test early stopping")
-
 test_that("validation uses correct dimensions", {
   expect_error(
     reg_fit <-

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -8,8 +8,12 @@ axe_test_data <- dplyr::tibble(
 
 # Test for expected outputs
 test_that("output is as expected", {
-  expect_equal(axe_tune_data(axe_test_data), axe_test_data[, 1:2], ignore_attr = TRUE)
-})})
+  expect_equal(
+    axe_tune_data(axe_test_data),
+    axe_test_data[, 1:2],
+    ignore_attr = TRUE
+  )
+})
 
 # Test that invalid inputs throw errors
 test_that("invalid data types stop process", {

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -39,8 +39,6 @@ test_that("invalid data types stop process", {
 })
 
 
-context("test lgbm_save() and lgbm_load()")
-
 ##### TEST lgbm_save() and lgbm_load() #####
 
 library(modeldata)

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -1,5 +1,3 @@
-context("test axe_tune_data()")
-
 ##### TEST axe_tune_data() #####
 
 axe_test_data <- dplyr::tibble(
@@ -19,8 +17,6 @@ test_that("invalid data types stop process", {
   expect_condition(axe_tune_data(8))
 })
 
-
-context("test axe_recipe()")
 
 ##### TEST axe_recipe() #####
 

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -8,8 +8,8 @@ axe_test_data <- dplyr::tibble(
 
 # Test for expected outputs
 test_that("output is as expected", {
-  expect_equivalent(axe_tune_data(axe_test_data), axe_test_data[, 1:2])
-})
+  expect_equal(axe_tune_data(axe_test_data), axe_test_data[, 1:2], ignore_attr = TRUE)
+})})
 
 # Test that invalid inputs throw errors
 test_that("invalid data types stop process", {

--- a/tests/testthat/test-hyperparameters.R
+++ b/tests/testthat/test-hyperparameters.R
@@ -1,5 +1,3 @@
-context("test hyperparameters")
-
 model <- parsnip::boost_tree() %>%
   parsnip::set_mode("regression")
 

--- a/tests/testthat/test-lightgbm.R
+++ b/tests/testthat/test-lightgbm.R
@@ -1,5 +1,3 @@
-context("test lightgbm regression")
-
 test_that("lightgbm regression", {
   model <- parsnip::boost_tree(trees = 50) %>%
     parsnip::set_engine(
@@ -122,8 +120,6 @@ test_that("lighgbm throws error", {
   )
 })
 
-
-context("test tune")
 
 test_that("lightgbm with tune", {
   model <- parsnip::boost_tree(


### PR DESCRIPTION
Follow-up on https://github.com/ccao-data/ccao/pull/51 to update testthat to version 3. Also removes context since that got deprecated.