### PR TITLE
Upgrade pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run pre-commit checks
-        uses: ccao-data/actions/pre-commit@jeancochrane/install-system-packages-for-r-pre-commit-hooks
+        uses: ccao-data/actions/pre-commit@jeancochrane/downgrade-r-to-4.4

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,5 +12,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3.24
+        with:
+          limit-access-to-actor: true
+
       - name: Run pre-commit checks
         uses: ccao-data/actions/pre-commit@main

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,10 +12,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3.24
-        with:
-          limit-access-to-actor: true
-
       - name: Run pre-commit checks
-        uses: ccao-data/actions/pre-commit@main
+        uses: ccao-data/actions/pre-commit@jeancochrane/install-system-packages-for-r-pre-commit-hooks

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run pre-commit checks
-        uses: ccao-data/actions/pre-commit@jeancochrane/downgrade-r-to-4.4
+        uses: ccao-data/actions/pre-commit@main

--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,4 @@
 linters: linters_with_defaults(
-    cyclocomp_linter = lintr::cyclocomp_linter(30),
     object_name_linter = NULL,
     object_usage_linter = NULL
   )

--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,6 @@
 linters: linters_with_defaults(
     object_name_linter = NULL,
-    object_usage_linter = NULL
+    object_usage_linter = NULL,
+    pipe_consistency_linter = pipe_consistency_linter(c("auto"))
   )
 encoding: "UTF-8"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # R specific hooks: https://github.com/lorenzwalthert/precommit
 repos:
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.2
+    rev: v0.4.3.9025
     hooks:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]
@@ -16,7 +16,7 @@ repos:
     -   id: deps-in-desc
         args: [--allow_private_imports]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
     -   id: check-added-large-files
         args: ['--maxkb=200']

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -17,7 +17,7 @@ axe_tune_data <- function(x) {
   attributes(stripped)$rset_info$att$splits <- NULL
   attributes(stripped)$rset_info$att$id <- NULL
 
-  return(stripped)
+  stripped
 }
 
 
@@ -43,7 +43,7 @@ axe_recipe <- function(x) {
   axed <- utils::modifyList(axed, list(orig_lvls = NULL))
   class(axed) <- "recipe"
 
-  return(axed)
+  axed
 }
 
 
@@ -99,5 +99,5 @@ lgbm_load <- function(zipfile) {
     model$fit$record_evals <- readRDS(record_evals_path)
   }
 
-  return(model)
+  model
 }

--- a/R/lightgbm.R
+++ b/R/lightgbm.R
@@ -255,7 +255,6 @@ train_lightgbm <- function(x,
   }
 
 
-
   ##### Train #####
   main_args <- list(
     params = arg_list,

--- a/vignettes/finding-comps.rmd
+++ b/vignettes/finding-comps.rmd
@@ -137,7 +137,7 @@ lgb.plot.tree <- function(model = NULL, tree = NULL, rules = NULL) {
       value = c("DimGray", "1.5", "vee", "Helvetica")
     )
 
-  return(graph)
+  graph
 }
 ```
 


### PR DESCRIPTION
The pre-commit workflow passed in the context of https://github.com/ccao-data/lightsnip/pull/23 but [failed after merging to main](https://github.com/ccao-data/lightsnip/actions/runs/26979682119/job/79615488931) because https://github.com/ccao-data/actions/pull/41 landed in between those two runs. That `actions` PR upgraded the installed version of R in the context of the `pre-commit` action, which then triggered the `digest` incompatibility that caused us to have to upgrade our R pre-commit hooks following our server upgrade from R 4.4 to 4.5. This PR upgrades our R pre-commit hooks to make them compatible with R 4.5; while we're at it, we also upgrade our other pre-commit hooks.

Note that upgrading R hooks to the latest version caused the R hooks renv environment to [fail to install](https://github.com/ccao-data/lightsnip/actions/runs/26981730051/job/79628666203) due to a tricky bug in one of its dependencies (https://github.com/jeroen/V8/issues/204). To work around that bug, we have to downgrade `ccao-data/actions/pre-commit` back to R 4.4 until the dependency builds are fixed. In the meantime, I figure we might as well stick with the upgraded version of the R hooks in this repo, since we will (hopefully) eventually upgrade `ccao-data/actions/pre-commit` back to R 4.5.